### PR TITLE
Fix memory leak in error event listener removal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,14 @@ function useWebWorker(config: { url?: string, worker?: Worker }) {
   }
 
   /**
+   *  OnErrorEvent handler for worker error events
+   *  Wraps onError to properly handle ErrorEvent objects
+   */
+  function onErrorEvent(errorEvent: ErrorEvent) {
+    onError(errorEvent.error);
+  }
+
+  /**
    *  if url is passed a new webworker is created using that url
    *  else it will use the worker which was passed in config
    */
@@ -71,9 +79,7 @@ function useWebWorker(config: { url?: string, worker?: Worker }) {
 
     if (worker) {
       worker.addEventListener('message', onMessage);
-      worker.addEventListener('error', (errorEvent) => {
-        onError(errorEvent.error);
-      });
+      worker.addEventListener('error', onErrorEvent);
     }
   }
 
@@ -103,9 +109,7 @@ function useWebWorker(config: { url?: string, worker?: Worker }) {
 
     if (worker) {
       worker.removeEventListener('message', onMessage);
-      worker.removeEventListener('error', (errorEvent) => {
-        onError(errorEvent.error);
-      });
+      worker.removeEventListener('error', onErrorEvent);
 
       if (shouldTerminate) {
         worker.terminate();


### PR DESCRIPTION
Previously, error event listeners were added as inline arrow functions
but removed with different arrow function instances, causing the
listeners to never be properly removed. This resulted in memory leaks
that accumulated with each component re-render.

Changes:
- Added onErrorEvent function to wrap error handling with a stable reference
- Updated addEventListener to use onErrorEvent function reference
- Updated removeEventListener to use the same onErrorEvent reference
- This ensures proper cleanup of event listeners on component unmount

The fix follows the same pattern used for the 'message' event listener,
which already used a stable function reference (onMessage).